### PR TITLE
students can add teacher accounts

### DIFF
--- a/client/components/AddTeacherAccountPage/AddTeacherAccountPage.jsx
+++ b/client/components/AddTeacherAccountPage/AddTeacherAccountPage.jsx
@@ -1,9 +1,6 @@
 import { useState } from "react";
 import { Navigate } from "react-router-dom";
 import { useUserContext } from "../../context/UserContext";
-import { updateUserType } from "../../services/auth";
-import { addTeacherAccount } from "../../services/teacher";
-import { getCityFromZipCode } from "../../services/zipcode";
 import Header from "../Header/Header";
 import TeacherBioForm from "../TeacherBioForm/TeacherBioForm";
 import TeacherLessonForm from "../TeacherLessonForm/TeacherLessonForm";
@@ -11,68 +8,28 @@ import TeacherLessonForm from "../TeacherLessonForm/TeacherLessonForm";
 export default function AddTeacherAccountPage() {
   const { user, setUser, doneGettingUser } = useUserContext();
   const [step, setStep] = useState(1);
-  const [showCity, setShowCity] = useState(false);
-  const [cityName, setCityName] = useState('');
-  const [stateName, setStateName] = useState('');
-  const [imageUrl, setImageUrl] = useState('');
-  const [subject, setSubject] = useState('');
-  const [zipCode, setZipCode] = useState('');
+  const [subjects, setSubjects] = useState([]);
 
   if (user && doneGettingUser && user.type === 'teacher') return <Navigate to='/my-students' />
   if (!user && doneGettingUser) return <Navigate to='/auth/sign-up/teacher' />
-
-  const handleEnterZipCode = async (e) => {
-    if (Number(e.target.value) && e.target.value.length === 5) {
-      const { city, state } = await getCityFromZipCode(e.target.value);
-      if (city && state) {
-        setShowCity(true);
-        setCityName(city);
-        setStateName(state);
-      }
-    }
-  }
-
-  const goToBioForm = (e) => {
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    setSubject(formData.get('subject'));
-    setZipCode(formData.get('zip'));
-    setStep(2)
-  }
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    const teacherData = await addTeacherAccount({
-      firstName: user.firstName,
-      lastName: user.lastName,
-      imageUrl: imageUrl || user.imageUrl,
-      subject,
-      bio: formData.get('bio'),
-      zipCode,
-      phoneNumber: formData.get('phoneNumber'),
-      contactEmail: formData.get('contactEmail'),
-      city: cityName,
-      state: stateName
-    });
-    await updateUserType('teacher');
-    setUser({ ...user, type: 'teacher', teacherId: teacherData.id });
-  }
 
   return (
     <>
       <Header />
       {step === 1 && 
         <TeacherLessonForm
-          handleNext={goToBioForm}
-          showCity={showCity}
-          handleEnterZipCode={handleEnterZipCode}
-          cityName={cityName}
-          stateName={stateName}
+          setSubjects={setSubjects}
+          setStep={setStep}
+          newUser={false}
         />
       }
       {step === 2 && 
-        <TeacherBioForm handleSubmit={handleSubmit} imageUrl={imageUrl} setImageUrl={setImageUrl} />
+        <TeacherBioForm 
+          subjects={subjects}
+          newUser={false}
+          setUser={setUser}
+          user={user}
+        />
       }
     </>
   )

--- a/client/components/TeacherAuth/TeacherAuth.jsx
+++ b/client/components/TeacherAuth/TeacherAuth.jsx
@@ -9,8 +9,6 @@ export default function TeacherAuth() {
   const [step, setStep] = useState(1);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [cityName, setCityName] = useState('');
-  const [stateName, setStateName] = useState('');
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [subjects, setSubjects] = useState([]);
@@ -35,6 +33,7 @@ export default function TeacherAuth() {
         <TeacherLessonForm
           setSubjects={setSubjects}
           setStep={setStep}
+          newUser={true}
         />
       }
       {step === 3 &&
@@ -44,11 +43,9 @@ export default function TeacherAuth() {
           firstName={firstName}
           lastName={lastName}
           subjects={subjects}
-          cityName={cityName}
-          setCityName={setCityName}
-          stateName={stateName}
-          setStateName={setStateName}
           setUser={setUser}
+          newUser={true}
+          user={user}
         />
       }
     </>

--- a/client/components/TeacherLessonForm/TeacherLessonForm.jsx
+++ b/client/components/TeacherLessonForm/TeacherLessonForm.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Button, Form } from "react-bootstrap";
 import SubjectInputs from "../SubjectInputs/SubjectInputs";
 
-export default function TeacherLessonForm({ setSubjects, setStep }) {
+export default function TeacherLessonForm({ setSubjects, setStep, newUser }) {
 
   const [formErrors, setFormErrors] = useState({});
   const [subjectNums, setSubjectNums] = useState([1]);
@@ -52,6 +52,10 @@ export default function TeacherLessonForm({ setSubjects, setStep }) {
       })
     }
     setSubjects(subjectFormData);
+    if (!newUser) {
+      setStep(2);
+      return;
+    }
     setStep(3);
   }
 

--- a/client/services/teacher.js
+++ b/client/services/teacher.js
@@ -46,7 +46,7 @@ export async function getStudents(id) {
   }
 }
 
-export async function addTeacherAccount({ firstName, lastName, imageUrl, subject, bio, zipCode, phoneNumber, contactEmail, city, state }) {
+export async function addTeacherAccount({ firstName, lastName, imageUrl, subjects, bio, zipCode, phoneNumber, contactEmail, city, state }) {
   const res = await fetch(`${process.env.API_FETCH_URL}/api/v1/teachers/add-account`, {
     method: "POST",
     credentials: "include",
@@ -58,7 +58,7 @@ export async function addTeacherAccount({ firstName, lastName, imageUrl, subject
       firstName,
       lastName,
       imageUrl,
-      subject,
+      subjects,
       bio,
       zipCode,
       phoneNumber,

--- a/server/controllers/connections.test.ts
+++ b/server/controllers/connections.test.ts
@@ -45,9 +45,10 @@ describe('connections controller', () => {
   })
   it('creates new pending connection on POST /connections', async () => {
     const { agent, student, teacher } = await createTeacherAndStudent();
+    await agent.delete('/users/sessions');
+    await agent.post('/users/sessions').send({ email: testStudent.email, password: testStudent.password });
     const res = await agent.post('/connections').send({
       teacherId: teacher.id,
-      studentId: student.id
     });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
@@ -59,6 +60,8 @@ describe('connections controller', () => {
   })
   it('updates connection status on PUT /connections', async () => {
     const { agent, student, teacher } = await createTeacherAndStudent();
+    await agent.delete('/users/sessions');
+    await agent.post('/users/sessions').send({ email: testStudent.email, password: testStudent.password });
     await agent.post('/connections').send({
       teacherId: teacher.id,
       studentId: student.id

--- a/server/controllers/connections.ts
+++ b/server/controllers/connections.ts
@@ -1,21 +1,21 @@
 import { Router } from 'express';
-import authenticate from '../middleware/authenticateStudent.js';
+import authenticateStudent from '../middleware/authenticateStudent.js';
 import Connection from '../models/Connection.js';
 
 export default Router()
-  .post('/', authenticate, async (req, res, next) => {
+  .post('/', authenticateStudent, async (req, res, next) => {
     try {
-      const newConnection = await Connection.create({ teacherId: req.body.teacherId, studentId: req.body.studentId, connectionApproved: 'pending' })
+      const newConnection = await Connection.create({ teacherId: req.body.teacherId, studentId: req.user.studentId, connectionApproved: 'pending' })
       res.json(newConnection);
     }
     catch (e) {
       next(e);
     }
   })
-  .put('/', authenticate, async (req, res, next) => {
+  .put('/', authenticateStudent, async (req, res, next) => {
     try {
       const updatedConnection = await Connection.update({ 
-        studentId: req.body.studentId,
+        studentId: req.user.studentId,
         teacherId: req.body.teacherId,
         connectionStatus: req.body.connectionStatus
       });

--- a/server/controllers/students.test.ts
+++ b/server/controllers/students.test.ts
@@ -16,6 +16,34 @@ const testStudent = {
   imageUrl: 'testimage.com'
 };
 
+const testTeacher = {
+  firstName: 'Test',
+  lastName: 'Teacher',
+  email: 'teacher@test.com',
+  password: '123456',
+  imageUrl: 'testimage.com',
+  bio: 'I am a teacher',
+  zipCode: '97214',
+  subjects: [{ subject: 'Drawing', minPrice: 10, maxPrice: 30, lessonType: 'In person' }],
+  phoneNumber: '5555555555',
+  contactEmail: 'teacher@test.com',
+  city: 'Portland',
+  state: 'OR'
+}
+
+const testSubject = {
+  subject: 'Coding',
+  minPrice: 40,
+  maxPrice: 60,
+  lessonType: 'Remote'
+}
+
+const testTeachingMaterial = {
+  url: 'materialtest.com',
+  type: 'link',
+  name: 'Test Material'
+}
+
 describe('students controller', () => {
   beforeEach(() => {
     return setupDb();
@@ -25,4 +53,68 @@ describe('students controller', () => {
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Signed in successfully!');
   })
+  it('creates a student profile for authenticated teacher at POST /students/add-account', async () => {
+    const agent = request.agent(app);
+    const teacherAuthRes = await agent.post('/teachers').send(testTeacher);
+    const res = await agent.post('/students/add-account').send(testTeacher);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: expect.any(String),
+      userId: teacherAuthRes.body.teacher.userId,
+      firstName: teacherAuthRes.body.teacher.firstName,
+      lastName: teacherAuthRes.body.teacher.lastName,
+      imageUrl: teacherAuthRes.body.teacher.imageUrl
+    });
+  });
+  it('gets student profile information at GET /students/me', async () => {
+    const agent = request.agent(app);
+    const studentAuthRes = await agent.post('/students').send(testStudent);
+    const res = await agent.get('/students/me');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: expect.any(String),
+      userId: studentAuthRes.body.student.userId,
+      firstName: studentAuthRes.body.student.firstName,
+      lastName: studentAuthRes.body.student.lastName,
+      imageUrl: studentAuthRes.body.student.imageUrl
+    })
+  });
+  it('serves a new student subject connection at POST /students/subject', async () => {
+    const agent = request.agent(app);
+    await agent.post('/teachers').send(testTeacher);
+    const newSubjectRes = await agent.post('/subjects').send(testSubject);
+    await agent.delete('/users/sessions');
+    const studentAuthRes = await agent.post('/students').send(testStudent);
+    const res = await agent.post('/students/subject').send({ subjectId: newSubjectRes.body.id });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: expect.any(String),
+      subjectId: newSubjectRes.body.id,
+      studentId: studentAuthRes.body.student.id
+    })
+  })
+  it("serves a student's learning materials at GET /students/learning-materials", async () => {
+    const agent = request.agent(app);
+    const teacherAuthRes = await agent.post('/teachers').send(testTeacher);
+    const subjectsRes = await agent.get(`/subjects/${teacherAuthRes.body.teacher.id}`);
+    const teachingMaterialsRes = await agent.post('/teaching-materials').send({ ...testTeachingMaterial, subjectId: subjectsRes.body[0].id });
+    const studentAuthRes = await agent.post('/students').send(testStudent);
+    await agent.post('/connections').send({
+      teacherId: teacherAuthRes.body.teacher.id
+    });
+    await agent.put('/connections').send({
+      teacherId: teacherAuthRes.body.teacher.id,
+      connectionStatus: 'approved'
+    });
+    await agent.post('/students/subject').send({
+      subjectId: subjectsRes.body[0].id
+    });
+    const res = await agent.get('/students/learning-materials');
+    console.log(res.body[0].teachingMaterials);
+    expect(res.status).toBe(200);
+    expect(res.body[0].teachingMaterials[0]).toEqual(
+      expect.objectContaining({
+      ...testTeachingMaterial
+    }))
+  });
 })

--- a/server/controllers/students.ts
+++ b/server/controllers/students.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import authenticateStudent from '../middleware/authenticateStudent.js';
+import authenticateTeacher from '../middleware/authenticateTeacher.js';
 import Student from '../models/Student.js';
 import StudentSubject from '../models/StudentSubject.js';
 import Teacher from '../models/Teacher.js';
@@ -34,9 +35,9 @@ export default Router()
       next(e);
     }
   })
-  .post('/add-account', async (req, res, next) => {
+  .post('/add-account', authenticateTeacher, async (req, res, next) => {
     try {
-      const student = Student.create({ ...req.body, userId: req.user.id });
+      const student = await Student.create({ ...req.body, userId: req.user.id });
       res.json(student);
     } catch (e) {
       next(e);

--- a/server/controllers/subjects.ts
+++ b/server/controllers/subjects.ts
@@ -23,7 +23,7 @@ export default Router()
   })
   .post('/', authenticateTeacher, async (req, res, next) => {
     try {
-      const newSubject = Subject.create({ ...req.body, teacherId: req.user.teacherId});
+      const newSubject = await Subject.create({ ...req.body, teacherId: req.user.teacherId});
       res.json(newSubject);
     } catch (e) {
       next(e);

--- a/server/controllers/teachers.ts
+++ b/server/controllers/teachers.ts
@@ -49,7 +49,11 @@ export default Router()
   })
   .post('/add-account', authenticateStudent, async (req, res, next) => {
     try {
+      const { subjects } = req.body;
       const teacher = await Teacher.create({ ...req.body, userId: req.user.id });
+      for (const subject of subjects) {
+        await Subject.create({ ...subject, teacherId: teacher.id });
+      }
       res.json(teacher);
     } catch (e) {
       next (e);
@@ -82,7 +86,7 @@ export default Router()
   })
   .put('/me', authenticateTeacher, async (req, res, next) => {
     try {
-      const updatedTeacher = Teacher.updateByUserId({ ...req.body, userId: req.user.id });
+      const updatedTeacher = await Teacher.updateByUserId({ ...req.body, userId: req.user.id });
       res.json(updatedTeacher);
     } catch (e) {
       next(e);

--- a/server/controllers/users.test.ts
+++ b/server/controllers/users.test.ts
@@ -115,4 +115,10 @@ describe('teachers controller', () => {
     const res = await agent.delete('/users/sessions');
     expect(res.status).toBe(204);
   })
+  it('updates user type on PUT /users/me', async () => {
+    const agent = await registerAndLoginStudent();
+    const res = await agent.put('/users/me').send({ type: 'teacher' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(expect.objectContaining({ type: 'teacher' }));
+  })
 })


### PR DESCRIPTION
This was working previously, but because of changes to the structure of the teacher sign up forms it needed to be fixed, specifically to account for multiple subjects and amount of state contained within the TeacherBioForm component